### PR TITLE
src/FlexibleUNet.jl: Add standard Dropout of given depth starting fro…

### DIFF
--- a/src/FlexibleUNet.jl
+++ b/src/FlexibleUNet.jl
@@ -20,7 +20,10 @@ end
         time_embedding=false,
         num_classes=0,
         embedding_dim=128,
-        time_emb_dim=256
+        time_emb_dim=256,
+        dropout=0.0,
+        dropout_depth=0,
+        activation=relu
     )
 
 A flexible UNet architecture with configurable depth and channel dimensions.
@@ -36,9 +39,23 @@ Supports optional time and class embeddings for diffusion models and conditional
 - `num_classes=0`: Number of class labels for conditional generation
 - `embedding_dim=128`: Dimension for class embeddings
 - `time_emb_dim=256`: Dimension for time embeddings
+- `dropout=0.0`: Dropout probability to apply to inner layers
+- `dropout_depth=0`: Number of layers to apply dropout to, starting from the innermost layers (0 means no dropout). Maximum value is 1+depth (bottleneck + all encoding/decoding levels)
+- `activation=relu`: Activation function to use throughout the network
 
 # Examples
 ```julia
+# Basic model without dropout
+model = FlexibleUNet(
+    in_channels=3,
+    out_channels=3,
+    depth=4,
+    base_channels=32,
+    channel_multipliers=[1, 2, 4, 8],
+    time_embedding=true
+)
+
+# Model with dropout applied to the 3 innermost layers
 model = FlexibleUNet(
     in_channels=3,
     out_channels=3,
@@ -46,10 +63,10 @@ model = FlexibleUNet(
     base_channels=32,
     channel_multipliers=[1, 2, 4, 8],
     time_embedding=true,
-    num_classes=10,
-    embedding_dim=128,
-    time_emb_dim=256
+    dropout=0.2,
+    dropout_depth=3
 )
+
 x = randn(Float32, 32, 32, 3, 1)
 t = randn(Float32, 1)
 labels = [5]
@@ -75,7 +92,10 @@ function FlexibleUNet(;
     time_embedding=false,
     num_classes=0,
     embedding_dim=128,
-    time_emb_dim=256
+    time_emb_dim=256,
+    dropout=0.0,
+    dropout_depth=0,
+    activation=relu
 )
     # Ensure we have enough channel multipliers for the requested depth
     if length(channel_multipliers) < depth
@@ -90,29 +110,54 @@ function FlexibleUNet(;
     # Calculate actual channel numbers
     channels = [base_channels * m for m in channel_multipliers]
 
-    # Create encoder blocks
+    # Calculate maximum possible dropout depth (bottleneck + all encoders/decoders symmetrically)
+    # Since we're applying dropout symmetrically, the maximum depth is bottleneck (1) + depth
+
+    # Limit dropout_depth to the maximum number of layers (bottleneck + depth)
+    dropout_depth = min(dropout_depth, 1 + depth)
+
+    # Bottleneck is considered the innermost layer (index 1)
+    dropout_bottleneck = dropout_depth >= 1 ? dropout : 0.0
+
+    # Create encoder blocks with appropriate dropout
     encoders = []
     input_ch = in_channels
     for i in 1:depth
+        # For encoders, the deepest is the one closest to the bottleneck (index = depth)
+        # Innermost encoder is at depth position, so we count from innermost outward
+        # Apply dropout if layer is within dropout_depth counting from the center
+        encoder_dropout = dropout_depth >= (depth - i + 1) ? dropout : 0.0
+
         encoder = EncoderBlock(input_ch, channels[i],
-                              time_emb=time_embedding,
-                              emb_dim=time_emb_dim)
+                             time_emb=time_embedding,
+                             emb_dim=time_emb_dim,
+                             dropout=encoder_dropout,
+                             activation=activation)
         push!(encoders, encoder)
         input_ch = channels[i]
     end
 
     # Create bottleneck
     bottleneck = Bottleneck(channels[end],
-                           time_emb=time_embedding,
-                           emb_dim=time_emb_dim)
+                          time_emb=time_embedding,
+                          emb_dim=time_emb_dim,
+                          dropout=dropout_bottleneck,
+                          activation=activation)
 
-    # Create decoder blocks
+    # Create decoder blocks with appropriate dropout
     decoders = []
     for i in depth:-1:1
         out_ch = i > 1 ? channels[i-1] : channels[1]
+
+        # For decoders, the deepest is the one closest to the bottleneck (first one)
+        # Apply dropout symmetrically with encoders
+        decoder_dropout = dropout_depth >= (depth - i + 1) ? dropout : 0.0
+
         decoder = DecoderBlock(channels[i], out_ch,
-                              time_emb=time_embedding,
-                              emb_dim=time_emb_dim)
+                             time_emb=time_embedding,
+                             emb_dim=time_emb_dim,
+                             dropout=decoder_dropout,
+                             activation=activation)
         push!(decoders, decoder)
     end
 

--- a/src/Onion.jl
+++ b/src/Onion.jl
@@ -29,7 +29,6 @@ export
     EncoderBlock,
     DecoderBlock,
     Bottleneck,
-    ResUNet,
     FlexibleUNet,
     # UNet helper functions:
     reverse_tuple,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,35 +46,6 @@ using Flux
             @test size(out) == (16, 16, 64, 2)
         end
 
-        # Test basic UNet forward pass
-        @testset "ResUNet Forward Pass" begin
-            model = Onion.ResUNet(
-                in_channels=3,
-                out_channels=3,
-                channels=[16, 32, 64],
-                time_embedding=true,
-                num_classes=10,
-                embedding_dim=32,
-                time_emb_dim=64
-            )
-
-            x = randn(Float32, 32, 32, 3, 2)
-            t = randn(Float32, 2)
-            labels = rand(1:10, 2)
-
-            # Test unconditional forward pass
-            y1 = model(x)
-            @test size(y1) == (32, 32, 3, 2)
-
-            # Test time-conditioned forward pass
-            y2 = model(x, t)
-            @test size(y2) == (32, 32, 3, 2)
-
-            # Test time+class-conditioned forward pass
-            y3 = model(x, t, labels)
-            @test size(y3) == (32, 32, 3, 2)
-        end
-
         # Test FlexibleUNet
         @testset "FlexibleUNet Forward Pass" begin
             model = Onion.FlexibleUNet(


### PR DESCRIPTION
- Remove fixed size ResUnet
- Add dropout to most inner layers controlable with depth parameter and dropout for dropout probability
- Remove one unnecessary convolution from bottleneck layer to conform with typical ResUnet architecture
