### PR TITLE
Add Dynamic Tanh (DyT) layer implementation

### DIFF
--- a/src/DyT.jl
+++ b/src/DyT.jl
@@ -1,0 +1,18 @@
+struct DyT{T <: AbstractFloat, V <: AbstractVector{T}}
+    alpha::V   # α
+    weight::V  # γ
+    bias::V    # β
+end
+
+Flux.@layer DyT
+
+"""
+    DyT(dim::Integer; init_alpha::T = 0.5f0)
+
+Make a Dynamic Tanh (DyT) layer for normalizing the input tensor.
+
+See [Transformers without Normalization](https://arxiv.org/abs/2503.10622) for more details.
+"""
+DyT(dim::Integer; init_alpha::T = 0.5f0) where T = DyT(ones(T, 1) .* init_alpha, ones(T, dim), zeros(T, dim))
+
+(dyt::DyT)(x) = @. dyt.weight * tanh(dyt.alpha * x) + dyt.bias

--- a/src/Onion.jl
+++ b/src/Onion.jl
@@ -5,6 +5,7 @@ using Flux, LinearAlgebra
 include("shared.jl")
 include("AdaLN.jl")
 include("RMSNorm.jl")
+include("DyT.jl")
 include("StarGLU.jl")
 include("GQAttention.jl")
 include("RoPE.jl")
@@ -17,6 +18,7 @@ export
     #layers:
     AdaLN,
     RMSNorm,
+    DyT,
     StarGLU,
     GQAttention,
     RoPE,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,4 +106,11 @@ using Flux
             @test size(y) == (32, 32, 8, 2)
         end
     end
+
+    @testset "DyT" begin
+        dyt = Onion.DyT(256)
+        x = randn(Float32, 256, 2)
+        y = dyt(x)
+        @test size(y) == size(x)
+    end
 end


### PR DESCRIPTION
This implements the DyT layer as proposed in https://arxiv.org/abs/2503.10622.
We might not use it, but I thought it would be useful to implement it here to avoid duplication of work.

The initial alpha parameter is chosen following their recommendation:
> For the scaler parameter α, a default initialization of 0.5 is generally sufficient, except for LLM training.