### PR TITLE
Add cross-attention support to Attention layer

### DIFF
--- a/src/GQAttention.jl
+++ b/src/GQAttention.jl
@@ -7,14 +7,21 @@ end
 """
     Attention(dim::Int, n_heads::Int, n_kv_heads=n_heads; qkv_bias=false)
 
-Attention layer for GQAttention (as in Llama3).
+Attention layer that supports both self-attention and cross-attention (as in Llama3).
 
+# Self-attention example
 ```julia
 dim = 64
 n_heads = 8
 n_kv_heads = 4
 
 attn = Attention(dim, n_heads, n_kv_heads)
+output = attn(x)  # Self-attention
+```
+
+# Cross-attention example
+```julia
+output = attn(query, key, value)  # Cross-attention
 ```
 """
 mutable struct Attention{DA, DB, DC, DD}
@@ -46,40 +53,52 @@ end
 
 repeat_kv(x::AbstractArray, n_rep::Int) = isone(n_rep) ? x : repeat(x, 1, n_rep, 1, 1)
 
-function (attn::Attention)(x::AbstractArray{T}, start_pos::Integer, rope=nothing, mask=0) where T
-    _, seqlen, batch = size(x)
+# Backward compatibility method for self-attention with existing interface
+function (attn::Attention)(x::AbstractArray{T}, start_pos::Integer=1, rope=nothing, mask=0) where T
+    return attn(x, nothing, nothing, start_pos, rope, mask)
+end
 
-    xq = attn.wq(x)
-    xk = attn.wk(x)
-    xv = attn.wv(x)
-
-    xq = reshape(xq, (attn.head_dim, attn.n_heads, seqlen, batch))
-    xk = reshape(xk, (attn.head_dim, attn.n_kv_heads, seqlen, batch))
-    xv = reshape(xv, (attn.head_dim, attn.n_kv_heads, seqlen, batch))
-
+function (attn::Attention)(query::AbstractArray{T}, key::Union{Nothing, AbstractArray{T}}=nothing, value::Union{Nothing, AbstractArray{T}}=nothing, start_pos::Integer=1, rope=nothing, mask=0) where T
+    # If key and value are not provided, use query (self-attention)
+    key = isnothing(key) ? query : key
+    value = isnothing(value) ? key : value
+    
+    _, q_seqlen, q_batch = size(query)
+    _, k_seqlen, k_batch = size(key)
+    
+    xq = attn.wq(query)
+    xk = attn.wk(key)
+    xv = attn.wv(value)
+    
+    xq = reshape(xq, (attn.head_dim, attn.n_heads, q_seqlen, q_batch))
+    xk = reshape(xk, (attn.head_dim, attn.n_kv_heads, k_seqlen, k_batch))
+    xv = reshape(xv, (attn.head_dim, attn.n_kv_heads, k_seqlen, k_batch))
+    
     xq = permutedims(xq, (1,3,2,4))
     xk = permutedims(xk, (1,3,2,4))
     xv = permutedims(xv, (1,3,2,4))
-
+    
     if rope isa RoPE
         xq, xk = rope(xq), rope(xk)
     end
-
+    
     # Update if cache is configured with seq_length > 0
     #xk, xv = update!(attn.cache, start_pos, xk, xv)
-
+    
+    # Repeat keys and values for multi-query attention if needed
     xk = repeat_kv(xk, attn.n_heads ÷ attn.n_kv_heads)
     xv = repeat_kv(xv, attn.n_heads ÷ attn.n_kv_heads)
-
-    xq_for_attn = reshape(xq, attn.head_dim, :, attn.n_heads * batch)
-    xk_for_attn = reshape(xk, attn.head_dim, :, attn.n_heads * batch)
-    xv_for_attn = reshape(xv, attn.head_dim, :, attn.n_heads * batch)
-
+    
+    xq_for_attn = reshape(xq, attn.head_dim, :, attn.n_heads * q_batch)
+    xk_for_attn = reshape(xk, attn.head_dim, :, attn.n_heads * k_batch)
+    xv_for_attn = reshape(xv, attn.head_dim, :, attn.n_heads * k_batch)
+    
     output = sdpa(xq_for_attn, xk_for_attn, xv_for_attn, attn.head_dim, mask)
     
-    e_output = reshape(output, (attn.head_dim, seqlen, attn.n_heads, batch))
+    e_output = reshape(output, (attn.head_dim, q_seqlen, attn.n_heads, q_batch))
     p_output = permutedims(e_output, (1,3,2,4)) 
-    r_output = reshape(p_output, (attn.n_heads * attn.head_dim, seqlen, batch))
+    r_output = reshape(p_output, (attn.n_heads * attn.head_dim, q_seqlen, q_batch))
+    
     proj = attn.wo(r_output)
     return proj
 end


### PR DESCRIPTION
Modified the Attention function to allow for different Q, K, and V matrices to enable cross-attention functionality. This maintains backward compatibility with the previous implementation since when the key is not specified, it defaults to the query (Q=K for self-attention) and the same holds for the value matrix.